### PR TITLE
Modified to enabled original src paths to be maintained in destination.

### DIFF
--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -22,17 +22,15 @@ module.exports = function(grunt)
             files = [],
             total = 0;
 
-        this.data.files.forEach(function(fset)
+        this.files.forEach(function(fset)
         {
-            var svg = grunt.file.expand(fset.src);
-
-            svg.forEach(function(svg)
+            fset.src.forEach(function(svg)
             {
-                var src = path.resolve(svg),
+                var src = path.resolve(fset.cwd + svg),
                     dest;
 
                 if (fset.dest) {
-                    dest = path.resolve(fset.dest) + '/' + path.basename(svg);
+                    dest = path.resolve(fset.dest) + '/' + svg;
                 } else {
                     dest = src;
                 }


### PR DESCRIPTION
I wanted the same directory structure to be recreated at destination as was found at the source which I don't think currently happens. I took a look at how svgmin does it and managed to create a solution. It does mean you have to set `cwd` in the config in order to separate it from the source files. 

```
files: [
    {
        cwd: 'src/img/',
        src: '**/*.svg',
        dest: 'build/img/'
    }
]
```

It basically uses `this.files` instead of `this.data.files` which already has a reference to the globbed files and gives you the ability to then keep the `cwd` part separate meaning you can then recreate the full directory path in the destination.

Also, I think this will solve the issue which is being talked about [here](https://github.com/dbushell/grunt-svg2png/issues/4)
