### PR TITLE
phantomjs version to 1.9.7 to fix mac osx install issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
 
     "dependencies": {
-        "phantomjs": "~1.x"
+        "phantomjs": "~1.9.7"
     },
 
     "devDependencies": {


### PR DESCRIPTION
Mac osx 10.9.2 failed to install phantomjs ~1.9.0
Setting version to 1.9.7. fixed the issue.
