### PR TITLE
Fixed the task when no cwd is used

### DIFF
--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -26,7 +26,7 @@ module.exports = function(grunt)
         {
             fset.src.forEach(function(svg)
             {
-                var src = path.resolve(fset.cwd + svg),
+                var src = path.resolve(fset.cwd || "" + svg),
                     dest;
 
                 if (fset.dest) {


### PR DESCRIPTION
If no cwd is present, `undefined` is appended to the path which breaks the task
