### PR TITLE
Use stdio rather than command line parameters to pass list of files to phantomjs

### DIFF
--- a/tasks/lib/svg2png.js
+++ b/tasks/lib/svg2png.js
@@ -7,8 +7,9 @@
  */
 
 var fs = require('fs'),
+    system = require('system'),
     page = require('webpage').create(),
-    files = JSON.parse(phantom.args[0]),
+    files = JSON.parse(system.stdin.read()),
     total = files.length,
     next = 0,
 

--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -99,20 +99,12 @@ module.exports = function(grunt)
             process.stdout.write(str + (hasTerminal ? '' : "\n"));
         };
 
-        var spawn = grunt.util.spawn({
-            cmd: phantomjs.path,
-            args: [
-                    path.resolve(__dirname, 'lib/svg2png.js'),
-                    JSON.stringify(files)
-                ]
-            },
-            function(err, result, code)
-            {
-                grunt.log.write("\n");
-                grunt.log.ok("Rasterization complete.");
-                done();
-            }
+        var spawn = require('child_process').spawn(
+            phantomjs.path,
+            [ path.resolve(__dirname, 'lib/svg2png.js') ]
         );
+        spawn.stdin.write(JSON.stringify(files));
+        spawn.stdin.end();
 
         spawn.stdout.on('data', function(buffer)
         {
@@ -123,6 +115,14 @@ module.exports = function(grunt)
                     update();
                 }
             } catch (e) { }
+        });
+
+        spawn.on('exit', function()
+        {
+            update();
+            grunt.log.write("\n");
+            grunt.log.ok("Rasterization complete.");
+            done();
         });
 
         update();


### PR DESCRIPTION
Use stdio rather than command line parameters to pass list of files to phantomjs

Avoids the ENAMETOOLONG error on Windows with a large number of files.

Fixes #17. Hopefully will be easier to accept for you than #18, the patch is a lot smaller.