### PR TITLE
If no files  have to be rasterized, it is not necessary to spawn the process

### DIFF
--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -44,6 +44,12 @@ module.exports = function(grunt)
             total = files.length;
         });
 
+        if (!total) {
+            grunt.log.subhead('No files to rasterize');
+            done();
+            return;
+        }
+
         grunt.log.subhead('Rasterizing SVG to PNG (' + files.length + ' files)...');
 
         var styles = {
@@ -74,10 +80,6 @@ module.exports = function(grunt)
 
         var update = function()
         {
-            if (!total) {
-                return;
-            }
-
             var hasTerminal = !!process.stdout.clearLine;
 
             if (hasTerminal) {


### PR DESCRIPTION
Only a very minor improvement, but we are running the SVG2PNG grunt task quite often in our project and noticed that it is spawning the phantom process irregardless of the actual existence of SVGs. A little time can be saved by exiting earlier if no files are present.