### PR TITLE
Quickfix for too long progress bar

### DIFF
--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -80,12 +80,6 @@ module.exports = function(grunt)
 
         var update = function()
         {
-            var hasTerminal = !!process.stdout.clearLine;
-
-            if (hasTerminal) {
-                process.stdout.clearLine();
-                process.stdout.cursorTo(0);
-            }
 
             var str = style('0%', 'yellow') + ' [ ',
                 arr = [],
@@ -97,6 +91,14 @@ module.exports = function(grunt)
             }
             str += arr.reverse().join('');
             str += ' ] ' + style(percent + "%", 'green') + ' (' + ((new Date() - start) / 1000).toFixed(1) + 's) ';
+
+            var hasTerminal = !!process.stdout.clearScreenDown;
+
+            if (hasTerminal) {
+                process.stdout.cursorTo(0);
+                process.stdout.moveCursor(0, -Math.floor(str.length / process.stdout.columns));
+                process.stdout.clearScreenDown();
+            }
 
             process.stdout.write(str + (hasTerminal ? '' : "\n"));
         };


### PR DESCRIPTION
Fixes issue #7 by clearing not only a single line, but as many lines as needed.

However, this still produces overly long progress bars with line breaks, which do not look pretty.
A final solution should consist of shortening the progress bar, as mentioned in issue #28.