### PR TITLE
Progress bar: Only show one line's worth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3425 @@
+{
+    "name": "grunt-svg2png",
+    "version": "0.2.7",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
+            "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.3.4",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.11",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+            "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
+            "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ==",
+            "dev": true
+        },
+        "@babel/template": {
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+            "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/types": "^7.2.2"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
+            "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.3.4",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.3.4",
+                "@babel/types": "^7.3.4",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.11"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.3.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
+            "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.11",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.10.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+            "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "arg": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+            "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                    "dev": true
+                }
+            }
+        },
+        "array-find-index": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+            "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws4": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "bind-obj-methods": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
+            "integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "browser-process-hrtime": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "camelcase": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "dev": true
+        },
+        "camelcase-keys": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
+            }
+        },
+        "capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+            "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "clean-yaml-object": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
+            "integrity": "sha1-Y/sRDcLOGoTcIfbZM0h20BCui2g=",
+            "dev": true
+        },
+        "cli": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+            "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+            "dev": true,
+            "requires": {
+                "exit": "0.1.2",
+                "glob": "^7.1.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "coffeescript": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
+            "integrity": "sha1-56qDAZF+9iGzXYo580jc3R234z4=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "dev": true
+        },
+        "colors": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                }
+            }
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "^0.1.4"
+            }
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "coveralls": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.3.tgz",
+            "integrity": "sha512-viNfeGlda2zJr8Gj1zqXpDMRjw9uM54p7wzZdvLRyOgnAfCe974Dq4veZkjJdxQXbmdppu6flEajFYseHYaUhg==",
+            "dev": true,
+            "requires": {
+                "growl": "~> 1.10.0",
+                "js-yaml": "^3.11.0",
+                "lcov-parse": "^0.0.10",
+                "log-driver": "^1.2.7",
+                "minimist": "^1.2.0",
+                "request": "^2.86.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+                    "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+                    "dev": true,
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                    "dev": true
+                },
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+                    "dev": true
+                },
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.12.2",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+                    "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "mime-types": {
+                    "version": "2.1.22",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+                    "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+                    "dev": true,
+                    "requires": {
+                        "mime-db": "~1.38.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    }
+                }
+            }
+        },
+        "cross-spawn": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+            "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
+            }
+        },
+        "currently-unhandled": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+            "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+            "dev": true,
+            "requires": {
+                "array-find-index": "^1.0.1"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "dateformat": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+            "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+            "dev": true,
+            "requires": {
+                "get-stdin": "^4.0.1",
+                "meow": "^3.3.0"
+            }
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "diff": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+            "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+            "dev": true
+        },
+        "dom-serializer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "^1.3.0",
+                "entities": "^1.1.1"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+                    "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+                    "dev": true
+                }
+            }
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+            "dev": true
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+            "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "ejs": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+            "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+            "dev": true
+        },
+        "entities": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+            "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+            "dev": true
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es6-promise": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+            "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "esm": {
+            "version": "3.2.16",
+            "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.16.tgz",
+            "integrity": "sha512-iACZMQvYFc66Y7QC+vD3oGA/fFsPA/IQwewRJ3K0gbMV52E59pdko02kF2TfVdtp5aHO62PHxL6fxtHJmhm3NQ==",
+            "dev": true
+        },
+        "esprima": {
+            "version": "2.7.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+            "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "eventemitter2": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+            "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+            "dev": true
+        },
+        "events-to-array": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+            "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+            "dev": true
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "extract-zip": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+            "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+            "requires": {
+                "concat-stream": "1.6.2",
+                "debug": "2.6.9",
+                "mkdirp": "0.5.1",
+                "yauzl": "2.4.1"
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "requires": {
+                "pend": "~1.2.0"
+            }
+        },
+        "find-up": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true,
+            "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+            }
+        },
+        "findup-sync": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+            "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+            "dev": true,
+            "requires": {
+                "glob": "~5.0.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "foreground-child": {
+            "version": "1.5.6",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
+            "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+            }
+        },
+        "fs-exists-cached": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz",
+            "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "function-loop": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.1.tgz",
+            "integrity": "sha1-gHa7MF6OajzO7ikgdl8zDRkPNAw=",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "dev": true
+        },
+        "getobject": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
+            "integrity": "sha1-BHpEl4n6Fg0Bj1SG7ZEyC27HiFw=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "glob": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+            "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.2",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "globals": {
+            "version": "11.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+            "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.1.15",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+            "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+            "dev": true
+        },
+        "grunt": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
+            "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
+            "dev": true,
+            "requires": {
+                "coffeescript": "~1.10.0",
+                "dateformat": "~1.0.12",
+                "eventemitter2": "~0.4.13",
+                "exit": "~0.1.1",
+                "findup-sync": "~0.3.0",
+                "glob": "~7.0.0",
+                "grunt-cli": "~1.2.0",
+                "grunt-known-options": "~1.1.0",
+                "grunt-legacy-log": "~2.0.0",
+                "grunt-legacy-util": "~1.1.1",
+                "iconv-lite": "~0.4.13",
+                "js-yaml": "~3.5.2",
+                "minimatch": "~3.0.2",
+                "mkdirp": "~0.5.1",
+                "nopt": "~3.0.6",
+                "path-is-absolute": "~1.0.0",
+                "rimraf": "~2.6.2"
+            },
+            "dependencies": {
+                "grunt-cli": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
+                    "integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
+                    "dev": true,
+                    "requires": {
+                        "findup-sync": "~0.3.0",
+                        "grunt-known-options": "~1.1.0",
+                        "nopt": "~3.0.6",
+                        "resolve": "~1.1.0"
+                    }
+                },
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "grunt-contrib-clean": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-2.0.0.tgz",
+            "integrity": "sha512-g5ZD3ORk6gMa5ugZosLDQl3dZO7cI3R14U75hTM+dVLVxdMNJCPVmwf9OUt4v4eWgpKKWWoVK9DZc1amJp4nQw==",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.1",
+                "rimraf": "^2.6.2"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+                    "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.11"
+                    }
+                }
+            }
+        },
+        "grunt-contrib-jshint": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-2.0.0.tgz",
+            "integrity": "sha512-4qR411I1bhvVrPkKBzCUcrWkTEtBuWioXi9ABWRXHoplRScg03jiMqLDpzS4pDhVsLOTx5F9l+0cnMc+Gd2MWg==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "hooker": "^0.2.3",
+                "jshint": "~2.9.6"
+            }
+        },
+        "grunt-contrib-nodeunit": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-nodeunit/-/grunt-contrib-nodeunit-2.0.0.tgz",
+            "integrity": "sha512-pt9N2Aj/6tlIgrepjUvPP4RfN58G7Zo/caL9O/9OskfRaY4qQCAF2n3H+AEUN/tq7nxrIFrAm6U3U+8gnpWDiw==",
+            "dev": true,
+            "requires": {
+                "nodeunit-x": "^0.12.1"
+            }
+        },
+        "grunt-known-options": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.1.tgz",
+            "integrity": "sha512-cHwsLqoighpu7TuYj5RonnEuxGVFnztcUqTqp5rXFGYL4OuPFofwC4Ycg7n9fYwvK6F5WbYgeVOwph9Crs2fsQ==",
+            "dev": true
+        },
+        "grunt-legacy-log": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
+            "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
+            "dev": true,
+            "requires": {
+                "colors": "~1.1.2",
+                "grunt-legacy-log-utils": "~2.0.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.5"
+            }
+        },
+        "grunt-legacy-log-utils": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
+            "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
+            "dev": true,
+            "requires": {
+                "chalk": "~2.4.1",
+                "lodash": "~4.17.10"
+            }
+        },
+        "grunt-legacy-util": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
+            "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
+            "dev": true,
+            "requires": {
+                "async": "~1.5.2",
+                "exit": "~0.1.1",
+                "getobject": "~0.1.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.10",
+                "underscore.string": "~3.3.4",
+                "which": "~1.3.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                }
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "hasha": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+            "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+            "requires": {
+                "is-stream": "^1.0.1",
+                "pinkie-promise": "^2.0.0"
+            }
+        },
+        "hooker": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+            "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+            "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
+            "dev": true
+        },
+        "htmlparser2": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+            "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1",
+                "domhandler": "2.3",
+                "domutils": "1.5",
+                "entities": "1.0",
+                "readable-stream": "1.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+            "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+            "dev": true,
+            "requires": {
+                "repeating": "^2.0.0"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+            "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+            "dev": true
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+            "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.0.0",
+                "@babel/parser": "^7.0.0",
+                "@babel/template": "^7.0.0",
+                "@babel/traverse": "^7.0.0",
+                "@babel/types": "^7.0.0",
+                "istanbul-lib-coverage": "^2.0.3",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+                    "dev": true
+                }
+            }
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
+            "integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.2",
+                "esprima": "^2.6.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
+        "jshint": {
+            "version": "2.9.7",
+            "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.7.tgz",
+            "integrity": "sha512-Q8XN38hGsVQhdlM+4gd1Xl7OB1VieSuCJf+fEJjpo59JH99bVJhXRXAh26qQ15wfdd1VPMuDWNeSWoNl53T4YA==",
+            "dev": true,
+            "requires": {
+                "cli": "~1.0.0",
+                "console-browserify": "1.1.x",
+                "exit": "0.1.x",
+                "htmlparser2": "3.8.x",
+                "lodash": "~4.17.10",
+                "minimatch": "~3.0.2",
+                "shelljs": "0.3.x",
+                "strip-json-comments": "1.0.x"
+            }
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsonfile": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "klaw": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+            "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+            "requires": {
+                "graceful-fs": "^4.1.9"
+            }
+        },
+        "lcov-parse": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
+            "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+            "dev": true
+        },
+        "load-json-file": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "dev": true
+        },
+        "log-driver": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+            "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+            "dev": true
+        },
+        "loud-rejection": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+            "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+            "dev": true,
+            "requires": {
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
+            }
+        },
+        "lru-cache": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+            "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+            "dev": true,
+            "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+            }
+        },
+        "make-error": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+            "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+            "dev": true
+        },
+        "map-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+            "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+            "dev": true
+        },
+        "meow": {
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+            "dev": true,
+            "requires": {
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                }
+            }
+        },
+        "mime-db": {
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+            "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "minipass": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+            "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+                    "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+                    "dev": true
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "nodeunit-x": {
+            "version": "0.12.1",
+            "resolved": "https://registry.npmjs.org/nodeunit-x/-/nodeunit-x-0.12.1.tgz",
+            "integrity": "sha512-CLnBQ4K303f3Qiau7vbwbKFraUyh1zR1kzrcv8D6nm3u3z7FATl8Jjj2gvyJelrpJisPoYMHjemvCS7VZBGqFg==",
+            "dev": true,
+            "requires": {
+                "ejs": "^2.5.2",
+                "tap": "^12.0.1"
+            }
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1"
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "nyc": {
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
+            "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "arrify": "^1.0.1",
+                "caching-transform": "^3.0.1",
+                "convert-source-map": "^1.6.0",
+                "find-cache-dir": "^2.0.0",
+                "find-up": "^3.0.0",
+                "foreground-child": "^1.5.6",
+                "glob": "^7.1.3",
+                "istanbul-lib-coverage": "^2.0.3",
+                "istanbul-lib-hook": "^2.0.3",
+                "istanbul-lib-instrument": "^3.1.0",
+                "istanbul-lib-report": "^2.0.4",
+                "istanbul-lib-source-maps": "^3.0.2",
+                "istanbul-reports": "^2.1.1",
+                "make-dir": "^1.3.0",
+                "merge-source-map": "^1.1.0",
+                "resolve-from": "^4.0.0",
+                "rimraf": "^2.6.3",
+                "signal-exit": "^3.0.2",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^5.1.0",
+                "uuid": "^3.3.2",
+                "yargs": "^12.0.5",
+                "yargs-parser": "^11.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "append-transform": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "default-require-extensions": "^2.0.0"
+                    }
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "arrify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "async": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.11"
+                    }
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "caching-transform": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hasha": "^3.0.0",
+                        "make-dir": "^1.3.0",
+                        "package-hash": "^3.0.0",
+                        "write-file-atomic": "^2.3.0"
+                    }
+                },
+                "camelcase": {
+                    "version": "5.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "commander": {
+                    "version": "2.17.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "commondir": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "convert-source-map": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "default-require-extensions": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.4.0"
+                    }
+                },
+                "error-ex": {
+                    "version": "1.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-arrayish": "^0.2.1"
+                    }
+                },
+                "es6-error": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "execa": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "cross-spawn": {
+                            "version": "6.0.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "nice-try": "^1.0.4",
+                                "path-key": "^2.0.1",
+                                "semver": "^5.5.0",
+                                "shebang-command": "^1.2.0",
+                                "which": "^1.2.9"
+                            }
+                        }
+                    }
+                },
+                "find-cache-dir": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "make-dir": "^1.0.0",
+                        "pkg-dir": "^3.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "foreground-child": {
+                    "version": "1.5.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^4",
+                        "signal-exit": "^3.0.0"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-caller-file": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.1.15",
+                    "bundled": true,
+                    "dev": true
+                },
+                "handlebars": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "async": "^2.5.0",
+                        "optimist": "^0.6.1",
+                        "source-map": "^0.6.1",
+                        "uglify-js": "^3.1.4"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "hasha": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-stream": "^1.0.1"
+                    }
+                },
+                "hosted-git-info": {
+                    "version": "2.7.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "invert-kv": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-arrayish": {
+                    "version": "0.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "istanbul-lib-coverage": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "istanbul-lib-hook": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "append-transform": "^1.0.0"
+                    }
+                },
+                "istanbul-lib-report": {
+                    "version": "2.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "istanbul-lib-coverage": "^2.0.3",
+                        "make-dir": "^1.3.0",
+                        "supports-color": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "6.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debug": "^4.1.1",
+                        "istanbul-lib-coverage": "^2.0.3",
+                        "make-dir": "^1.3.0",
+                        "rimraf": "^2.6.2",
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "istanbul-reports": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "handlebars": "^4.1.0"
+                    }
+                },
+                "json-parse-better-errors": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lcid": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^2.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.flattendeep": {
+                    "version": "4.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "make-dir": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "map-age-cleaner": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-defer": "^1.0.0"
+                    }
+                },
+                "mem": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^1.0.0",
+                        "p-is-promise": "^2.0.0"
+                    }
+                },
+                "merge-source-map": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.10",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "nice-try": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "normalize-package-data": {
+                    "version": "2.5.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.1.4",
+                        "resolve": "^1.10.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "optimist": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "~0.0.1",
+                        "wordwrap": "~0.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
+                    }
+                },
+                "p-defer": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-is-promise": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "p-try": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "package-hash": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.15",
+                        "hasha": "^3.0.0",
+                        "lodash.flattendeep": "^4.4.0",
+                        "release-zalgo": "^1.0.0"
+                    }
+                },
+                "parse-json": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
+                "read-pkg": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^3.0.0"
+                    }
+                },
+                "release-zalgo": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "es6-error": "^4.0.1"
+                    }
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "resolve": {
+                    "version": "1.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.6.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spawn-wrap": {
+                    "version": "1.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "foreground-child": "^1.5.6",
+                        "mkdirp": "^0.5.0",
+                        "os-homedir": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "signal-exit": "^3.0.2",
+                        "which": "^1.3.0"
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "test-exclude": {
+                    "version": "5.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arrify": "^1.0.1",
+                        "minimatch": "^3.0.4",
+                        "read-pkg-up": "^4.0.0",
+                        "require-main-filename": "^1.0.1"
+                    }
+                },
+                "uglify-js": {
+                    "version": "3.4.9",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "commander": "~2.17.1",
+                        "source-map": "~0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "uuid": {
+                    "version": "3.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "2.1.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^2.0.0"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "2.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "y18n": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "12.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^3.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "11.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "opener": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
+            "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+            "dev": true
+        },
+        "own-or": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/own-or/-/own-or-1.0.0.tgz",
+            "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+            "dev": true
+        },
+        "own-or-env": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
+            "integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+            "dev": true,
+            "requires": {
+                "own-or": "^1.0.0"
+            }
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.2.0"
+            }
+        },
+        "path-exists": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true,
+            "requires": {
+                "pinkie-promise": "^2.0.0"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "dev": true
+        },
+        "path-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+            }
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "phantomjs-prebuilt": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+            "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+            "requires": {
+                "es6-promise": "^4.0.3",
+                "extract-zip": "^1.6.5",
+                "fs-extra": "^1.0.0",
+                "hasha": "^2.2.0",
+                "kew": "^0.7.0",
+                "progress": "^1.1.8",
+                "request": "^2.81.0",
+                "request-progress": "^2.0.1",
+                "which": "^1.2.10"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+                },
+                "combined-stream": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+                    "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+                    "requires": {
+                        "delayed-stream": "~1.0.0"
+                    }
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                    "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+                },
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "fs-extra": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+                    "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^2.1.0",
+                        "klaw": "^1.0.0"
+                    }
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "requires": {
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
+                    }
+                },
+                "kew": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+                    "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
+                },
+                "mime-types": {
+                    "version": "2.1.22",
+                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+                    "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+                    "requires": {
+                        "mime-db": "~1.38.0"
+                    }
+                },
+                "oauth-sign": {
+                    "version": "0.9.0",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+                },
+                "request": {
+                    "version": "2.88.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+                    "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.8.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.6",
+                        "extend": "~3.0.2",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.2",
+                        "har-validator": "~5.1.0",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.19",
+                        "oauth-sign": "~0.9.0",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.2",
+                        "safe-buffer": "^5.1.2",
+                        "tough-cookie": "~2.4.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.3.2"
+                    }
+                },
+                "request-progress": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+                    "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+                    "requires": {
+                        "throttleit": "^1.0.0"
+                    }
+                },
+                "throttleit": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+                    "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "requires": {
+                "pinkie": "^2.0.0"
+            }
+        },
+        "pngjs": {
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+            "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "progress": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "psl": {
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "read-pkg": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true,
+            "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+            }
+        },
+        "redent": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "dev": true,
+            "requires": {
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
+            }
+        },
+        "repeating": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+            "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+            "dev": true,
+            "requires": {
+                "is-finite": "^1.0.0"
+            }
+        },
+        "resolve": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+            "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "semver": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+            "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+            "dev": true
+        },
+        "shelljs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+            "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+            "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+            "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+            "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
+            "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+            "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            },
+            "dependencies": {
+                "asn1": {
+                    "version": "0.2.4",
+                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+                    "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+                    "requires": {
+                        "safer-buffer": "~2.1.0"
+                    }
+                },
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "stack-utils": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+            "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "^0.2.0"
+            }
+        },
+        "strip-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+            "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+            "dev": true,
+            "requires": {
+                "get-stdin": "^4.0.1"
+            }
+        },
+        "strip-json-comments": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+            "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "tap": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/tap/-/tap-12.6.0.tgz",
+            "integrity": "sha512-HsU8Djx7WhkP8SZbtdtb1P/g74QdMYgLtge9/MiNZ2uKXa1KV36nHgWIFI0BlrhnzcS9n3WfqmLY2tIBTjl+ew==",
+            "dev": true,
+            "requires": {
+                "bind-obj-methods": "^2.0.0",
+                "browser-process-hrtime": "^1.0.0",
+                "capture-stack-trace": "^1.0.0",
+                "clean-yaml-object": "^0.1.0",
+                "color-support": "^1.1.0",
+                "coveralls": "^3.0.2",
+                "domain-browser": "^1.2.0",
+                "esm": "^3.2.5",
+                "foreground-child": "^1.3.3",
+                "fs-exists-cached": "^1.0.0",
+                "function-loop": "^1.0.1",
+                "glob": "^7.1.3",
+                "isexe": "^2.0.0",
+                "js-yaml": "^3.12.1",
+                "minipass": "^2.3.5",
+                "mkdirp": "^0.5.1",
+                "nyc": "^13.3.0",
+                "opener": "^1.5.1",
+                "os-homedir": "^1.0.2",
+                "own-or": "^1.0.0",
+                "own-or-env": "^1.0.1",
+                "rimraf": "^2.6.3",
+                "signal-exit": "^3.0.0",
+                "source-map-support": "^0.5.10",
+                "stack-utils": "^1.0.2",
+                "tap-mocha-reporter": "^3.0.9",
+                "tap-parser": "^7.0.0",
+                "tmatch": "^4.0.0",
+                "trivial-deferred": "^1.0.1",
+                "ts-node": "^8.0.2",
+                "tsame": "^2.0.1",
+                "typescript": "^3.3.3",
+                "write-file-atomic": "^2.4.2",
+                "yapool": "^1.0.0"
+            },
+            "dependencies": {
+                "esprima": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+                    "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+                    "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.12.2",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+                    "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+                    "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                    "dev": true
+                }
+            }
+        },
+        "tap-mocha-reporter": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-3.0.9.tgz",
+            "integrity": "sha512-VO07vhC9EG27EZdOe7bWBj1ldbK+DL9TnRadOgdQmiQOVZjFpUEQuuqO7+rNSO2kfmkq5hWeluYXDWNG/ytXTQ==",
+            "dev": true,
+            "requires": {
+                "color-support": "^1.1.0",
+                "debug": "^2.1.3",
+                "diff": "^1.3.2",
+                "escape-string-regexp": "^1.0.3",
+                "glob": "^7.0.5",
+                "js-yaml": "^3.3.1",
+                "readable-stream": "^2.1.5",
+                "tap-parser": "^5.1.0",
+                "unicode-length": "^1.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "2.3.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "tap-parser": {
+                    "version": "5.4.0",
+                    "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-5.4.0.tgz",
+                    "integrity": "sha512-BIsIaGqv7uTQgTW1KLTMNPSEQf4zDDPgYOBRdgOfuB+JFOLRBfEu6cLa/KvMvmqggu1FKXDfitjLwsq4827RvA==",
+                    "dev": true,
+                    "requires": {
+                        "events-to-array": "^1.0.1",
+                        "js-yaml": "^3.2.7",
+                        "readable-stream": "^2"
+                    }
+                }
+            }
+        },
+        "tap-parser": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-7.0.0.tgz",
+            "integrity": "sha512-05G8/LrzqOOFvZhhAk32wsGiPZ1lfUrl+iV7+OkKgfofZxiceZWMHkKmow71YsyVQ8IvGBP2EjcIjE5gL4l5lA==",
+            "dev": true,
+            "requires": {
+                "events-to-array": "^1.0.1",
+                "js-yaml": "^3.2.7",
+                "minipass": "^2.2.0"
+            }
+        },
+        "tmatch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-4.0.0.tgz",
+            "integrity": "sha512-Ynn2Gsp+oCvYScQXeV+cCs7citRDilq0qDXA6tuvFwDgiYyyaq7D5vKUlAPezzZR5NDobc/QMeN6e5guOYmvxg==",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                }
+            }
+        },
+        "trim-newlines": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+            "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "trivial-deferred": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
+            "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
+            "dev": true
+        },
+        "ts-node": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.3.tgz",
+            "integrity": "sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==",
+            "dev": true,
+            "requires": {
+                "arg": "^4.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^3.0.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "3.5.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+                    "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+                    "dev": true
+                }
+            }
+        },
+        "tsame": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/tsame/-/tsame-2.0.1.tgz",
+            "integrity": "sha512-jxyxgKVKa4Bh5dPcO42TJL22lIvfd9LOVJwdovKOnJa4TLLrHxquK+DlGm4rkGmrcur+GRx+x4oW00O2pY/fFw==",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+        },
+        "typescript": {
+            "version": "3.3.3333",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
+            "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+            "dev": true
+        },
+        "underscore.string": {
+            "version": "3.3.5",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+            "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
+            }
+        },
+        "unicode-length": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
+            "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+            "dev": true,
+            "requires": {
+                "punycode": "^1.3.2",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+                }
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "write-file-atomic": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
+            "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        },
+        "yapool": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/yapool/-/yapool-1.0.0.tgz",
+            "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
+            "dev": true
+        },
+        "yauzl": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+            "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+            "requires": {
+                "fd-slicer": "~1.0.1"
+            }
+        },
+        "yn": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-3.0.0.tgz",
+            "integrity": "sha512-+Wo/p5VRfxUgBUGy2j/6KX2mj9AYJWOHuhMjMcbBFc3y54o9/4buK1ksBvuiK01C3kby8DH9lSmJdSxw+4G/2Q==",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs/commit/46e52fdea1780bdb0c184fe04cbff7d5aa366c03"
+        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs.git#46e52fdea1780bdb0c184fe04cbff7d5aa366c03"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "2.1.7"
+        "phantomjs-prebuilt": "2.1.14"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,15 +37,15 @@
     },
 
     "devDependencies": {
-        "grunt": "~0.4.0",
-        "grunt-contrib-jshint": "~0.2.0",
-        "grunt-contrib-nodeunit": "~0.1.2",
-        "grunt-contrib-clean": "~0.4.0",
-        "pngjs": "~0.4.0"
+        "grunt": "0.4.5",
+        "grunt-contrib-jshint": "1.0.0",
+        "grunt-contrib-nodeunit": "0.4.1",
+        "grunt-contrib-clean": "1.0.0",
+        "pngjs": "2.2.0"
     },
 
     "peerDependencies": {
-        "grunt": "~0.4.0"
+        "grunt": "0.4.5"
     },
 
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs.git#v2.1.6-wmf"
+        "phantomjs-prebuilt": "2.1.7"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     },
 
     "dependencies": {
-        "phantomjs": "~1.9.0"
+        "phantomjs-prebuilt": "2.1.4"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs.git#46e52fdea1780bdb0c184fe04cbff7d5aa366c03"
+        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs.git#149b897a21e6819de40df51b6d22f2b3e88e44ce"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs.git#149b897a21e6819de40df51b6d22f2b3e88e44ce"
+        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs.git#v2.1.6-wmf"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "2.1.6"
+        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs/commit/46e52fdea1780bdb0c184fe04cbff7d5aa366c03"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,45 +1,34 @@
 {
     "name": "grunt-svg2png",
-
     "description": "Grunt plugin to rasterize SVG to PNG images using PhantomJS",
-
     "version": "0.2.7",
-
     "author": {
         "name": "David Bushell",
         "email": "hi@dbushell.com",
         "url": "http://dbushell.com/"
     },
-
     "homepage": "https://github.com/dbushell/grunt-svg2png",
-
     "repository": {
         "type": "git",
         "url": "git://github.com/dbushell/grunt-svg2png.git"
     },
-
     "bugs": {
         "url": "https://github.com/dbushell/grunt-svg2png/issues"
     },
-
     "main": "Gruntfile.js",
-
     "scripts": {
         "test": "grunt test"
     },
-
     "dependencies": {
-        "phantomjs-prebuilt": "2.1.14"
+        "phantomjs-prebuilt": "2.1.16"
     },
-
     "devDependencies": {
-        "grunt": "0.4.5",
-        "grunt-contrib-jshint": "1.0.0",
-        "grunt-contrib-nodeunit": "0.4.1",
-        "grunt-contrib-clean": "1.0.0",
-        "pngjs": "3.0.1"
+        "grunt": "1.0.3",
+        "grunt-contrib-jshint": "2.0.0",
+        "grunt-contrib-nodeunit": "2.0.0",
+        "grunt-contrib-clean": "2.0.0",
+        "pngjs": "3.4.0"
     },
-
     "keywords": [
         "svg",
         "png",
@@ -52,13 +41,11 @@
         "phantom",
         "phantomjs"
     ],
-
     "contributors": [
         {
             "name": "David Bushell",
             "url": "http://dbushell.com/"
         }
     ],
-
     "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -24,16 +24,12 @@
 
     "main": "Gruntfile.js",
 
-    "engines": {
-        "node": ">=0.8.0"
-    },
-
     "scripts": {
         "test": "grunt test"
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "2.1.4"
+        "phantomjs-prebuilt": "2.1.5"
     },
 
     "devDependencies": {
@@ -42,10 +38,6 @@
         "grunt-contrib-nodeunit": "0.4.1",
         "grunt-contrib-clean": "1.0.0",
         "pngjs": "2.2.0"
-    },
-
-    "peerDependencies": {
-        "grunt": "0.4.5"
     },
 
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "grunt-contrib-jshint": "1.0.0",
         "grunt-contrib-nodeunit": "0.4.1",
         "grunt-contrib-clean": "1.0.0",
-        "pngjs": "2.2.0"
+        "pngjs": "3.0.1"
     },
 
     "keywords": [

--- a/package.json
+++ b/package.json
@@ -68,10 +68,5 @@
         }
     ],
 
-    "licenses": [
-        {
-            "type": "MIT",
-            "url": "https://raw.github.com/dbushell/grunt-svg2png/master/LICENSE.txt"
-        }
-    ]
+    "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "2.1.5"
+        "phantomjs-prebuilt": "2.1.6"
     },
 
     "devDependencies": {

--- a/tasks/lib/svg2png.js
+++ b/tasks/lib/svg2png.js
@@ -38,8 +38,11 @@ var nextFile = function()
         height: parseFloat(height)
     };
 
+    // Prefix 'file://' to convert the local file path to a valid URL.
+    // Windows needs an extra slash before the drive letter ('C:\' etc.)
+    var url = 'file://' + (file.src[0] === '/' ? '' : '/') + file.src;
     // page.open('data:image/svg+xml;utf8,' + svgdata, function(status)
-    page.open(file.src, function(status)
+    page.open(url, function(status)
     {
         page.render(file.dest);
         console.log(JSON.stringify({ 'file': file, 'status': status }));

--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -88,14 +88,11 @@ module.exports = function(grunt)
             }
 
             var str = style('0%', 'yellow') + ' [ ',
-                arr = [],
-                count = total,
+                maxWidth = (process.stdout.columns - 25) || 30,
                 percent = ((100 / total) * completed).toFixed(2);
 
-            while(count--) {
-                arr.push(count < completed ? '=' : ' ');
-            }
-            str += arr.reverse().join('');
+            str += Array( Math.floor( maxWidth * percent / 100 ) + 1 ).join( '=' );
+            str += Array( maxWidth - Math.floor( maxWidth * percent / 100 ) + 1 ).join( ' ' );
             str += ' ] ' + style(percent + "%", 'green') + ' (' + ((new Date() - start) / 1000).toFixed(1) + 's) ';
 
             process.stdout.write(str + (hasTerminal ? '' : "\n"));

--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var phantomjs = require('phantomjs-prebuild'),
+var phantomjs = require('phantomjs-prebuilt'),
     path = require('path');
 
 module.exports = function(grunt)

--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var phantomjs = require('phantomjs'),
+var phantomjs = require('phantomjs-prebuild'),
     path = require('path');
 
 module.exports = function(grunt)


### PR DESCRIPTION
I'm picking 25 less than `process.stdout.columns` which is possibly a bit pessimistic for some users, but works well enough for my repo (with > 700 SVGs to convert). Possibly if it was going to take > 99s it'd be a pain. :-)

Fixes #28
