### PR TITLE
Get width and height values from viewBox attribute

### DIFF
--- a/tasks/lib/svg2png.js
+++ b/tasks/lib/svg2png.js
@@ -30,8 +30,8 @@ var nextFile = function()
     frag.innerHTML = svgdata;
 
     svg = frag.querySelector('svg');
-    width = svg.getAttribute('width');
-    height = svg.getAttribute('height');
+    width = svg.getAttribute('width') || svg.getAttribute('viewBox').split(" ")[2];
+    height = svg.getAttribute('height') || svg.getAttribute('viewBox').split(" ")[3];
 
     page.viewportSize = {
         width: parseFloat(width),


### PR DESCRIPTION
Edited the width and height variables assignment to get values from viewBox attribute when width and height attributes are not present.