### PR TITLE
Abort grunt task if any error has occurred during rasterization

### DIFF
--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -116,7 +116,17 @@ module.exports = function(grunt)
                     completed++;
                     update();
                 }
-            } catch (e) { }
+            } catch (e) {
+                grunt.log.write("\n");
+                grunt.log.error(e);
+                done(new Error("Rasterization failed!"));
+            }
+        });
+
+        spawn.stderr.on('data', function (buffer) {
+            grunt.log.write("\n");
+            grunt.log.error(buffer);
+            done(new Error("Rasterization failed!"));
         });
 
         spawn.on('exit', function()


### PR DESCRIPTION
Hi David,
today I noticed that the whole grunt build will hang if an error has occurred during rasterization. I have therefore fleshed-out the error handling. The grunt task is now aborted correctly.

Please consider merging the changes. Thanks in advance!

Regards,
Christian