### PR TITLE
Uses a carraige return instead of a new line in progress bar.

### DIFF
--- a/tasks/svg2png.js
+++ b/tasks/svg2png.js
@@ -98,7 +98,7 @@ module.exports = function(grunt)
             str += arr.reverse().join('');
             str += ' ] ' + style(percent + "%", 'green') + ' (' + ((new Date() - start) / 1000).toFixed(1) + 's) ';
 
-            process.stdout.write(str + (hasTerminal ? '' : "\n"));
+            process.stdout.write(str + (hasTerminal ? '' : "\r"));
         };
 
         var spawn = require('child_process').spawn(


### PR DESCRIPTION
Resolves #44 